### PR TITLE
Fix CMake not finding `SetSystemProcessor` module when using the library as an external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ mark_as_advanced (WITH_HI_PREC_CLOCK WITH_FLOAT_STD_PREC_CLOCK
 
 # Introspection:
 
-list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
 include (CheckFunctionExists)
 include (CheckIncludeFiles)


### PR DESCRIPTION
This fixes the issue of CMake not being able to find
the `SetSystemProcessor` module.

`CMAKE_CURRENT_SOURCE_DIR` points to the current `CMakeLists.txt`
being processed, which in this case is in the root of the repo.

`CMAKE_SOURCE_DIR` points to the top-level root of the project,
which is not the same as soxr's root directory when the library
is used as an external project.

This is a problem when using `soxr` as an external project
using CMake's `ExternalProject` module. Since in that case
CMake is unable to find the `SetSystemProcessor` (included
as `${CMAKE_SOURCE_DIR}/cmake/Modules`) because the variable
is expanded to the outer project's root, not `soxr`'s.

This includes the module as `${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules`
which expands to the correct path. 