### PR TITLE
Update CMake module path to use current source dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ mark_as_advanced (WITH_HI_PREC_CLOCK WITH_FLOAT_STD_PREC_CLOCK
 
 # Introspection:
 
-list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
 include (CheckFunctionExists)
 include (CheckIncludeFiles)


### PR DESCRIPTION
This allows building the library directly from another project's CMakeLists.txt by adding it as a subdirectory (add_subdirectory).

Otherwise the build will fail as it can't find the required modules for soxr.